### PR TITLE
writer: Fix option generation

### DIFF
--- a/microcoapy/coap_writer.py
+++ b/microcoapy/coap_writer.py
@@ -29,7 +29,8 @@ def writePacketHeaderInfo(buffer, packet):
 def writePacketOptions(buffer, packet):
     runningDelta = 0
     # make option header
-    for opt in packet.options:
+    # Process the options in ascending order of option number for correct delta computation.
+    for opt in sorted(packet.options, key=lambda x: x.number):
         if (opt is None) or (opt.buffer is None) or (len(opt.buffer) == 0):
             continue
 


### PR DESCRIPTION
I ran into a problem when adding options to a packet. It appears to be caused by options not being processed in the correct order. This needs to happen in ascending order of option number, so that the delta computation works as intended.

Here's the packet generated for `{ path: "hello", query="foo=bar", observe=0 }`:

```
Raw input data:
  Offset  00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
00000000  40 01 6E 0C D7 02 66 6F 6F 3D 62 61 72 71 00 55  @.n.×.foo=barq.U
00000010  68 65 6C 6C 6F                                   hello

Decoded CoAP packet:
{
  "code": "0.01",
  "confirmable": true,
  "reset": false,
  "ack": false,
  "messageId": 28172,
  "token": "",
  "options": [
    {
      "name": "Uri-Query",
      "value": "66 6f 6f 3d 62 61 72 |foo=bar| (7 bytes)"
    },
    {
      "name": "22",
      "value": "00 |.| (1 bytes)"
    },
    {
      "name": "Block1",
      "value": "68 65 6c 6c 6f |hello| (5 bytes)"
    }
  ],
  "payload": ""
}
```

Note the invalid options in there.

With the proposed patch I get the expected result instead:

```
Raw input data:
  Offset  00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
00000000  40 01 94 B9 61 00 55 68 65 6C 6C 6F 47 66 6F 6F  @.¹a.UhelloGfoo
00000010  3D 62 61 72                                      =bar

Decoded CoAP packet:
{
  "code": "0.01",
  "confirmable": true,
  "reset": false,
  "ack": false,
  "messageId": 38073,
  "token": "",
  "options": [
    {
      "name": "Observe",
      "value": "00 |.| (1 bytes)"
    },
    {
      "name": "Uri-Path",
      "value": "68 65 6c 6c 6f |hello| (5 bytes)"
    },
    {
      "name": "Uri-Query",
      "value": "66 6f 6f 3d 62 61 72 |foo=bar| (7 bytes)"
    }
  ],
  "payload": ""
}
```

FWIW, the decoding was done with the help of a small tool that uses the `coap-packet` JavaScript library:
https://github.com/mrubli/coap-packet/blob/feature/decode-example/examples/decode.js

Disclaimer: I've been using CPython for all my testing but I'm fairly sure the bug and its fix apply to MicroPython as well.